### PR TITLE
Fix Boo build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Boo.MonoDevelop/obj
+UnityScript.MonoDevelop/obj
+build-mpacks
+build
+external/Boo
+external/UnityScript

--- a/Boo.MonoDevelop/Boo.MonoDevelop.csproj
+++ b/Boo.MonoDevelop/Boo.MonoDevelop.csproj
@@ -83,6 +83,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\external\UnityScript\UnityScript.dll">
+      <Link>Boo\UnityScript.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="..\external\Boo\Boo.Lang.CodeDom.dll">
       <Link>Boo\Boo.Lang.CodeDom.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Copy UnityScript.dll to Boo compiler directory. Required in order for Boo compiler to be able to load UnityEditor.dll reference. Fixes case 825732